### PR TITLE
starlark/scan.star: better error handling

### DIFF
--- a/starlark/scan.star
+++ b/starlark/scan.star
@@ -30,7 +30,8 @@ def sast_scan(task_name, git_name, image="shiftleft/scan:latest", src=None, extr
     if not src:
         src = git_checkout_dir(git_name)
     output_name = storage_resource("storage-{}".format(task_name))
-
+    if not extra_scan_options:
+        extra_scan_options=[]
     task(task_name, inputs=[git_name], outputs=[output_name], steps=[
         k8s.corev1.Container(
             name="sast-scan-shiftleft-{}".format(git_name),
@@ -41,5 +42,6 @@ def sast_scan(task_name, git_name, image="shiftleft/scan:latest", src=None, extr
                 "--src={}".format(src),
                 "--out_dir={}".format("$(resources.outputs.{}.path)".format(output_name)),
             ] + extra_scan_options,
-        )], **kwargs)
+            **kwargs
+        )])
     return output_name


### PR DESCRIPTION
- Send `kwargs` correctly to container instead of task
- Initialize `extra_scan_options` to an empty list 