### PR TITLE
Generate a valid findings.json

### DIFF
--- a/lib/inspect.py
+++ b/lib/inspect.py
@@ -317,6 +317,7 @@ def convert_sarif(app_name, repo_context, sarif_files, findings_fname):
                             for r in run.get("tool", {}).get("driver", {}).get("rules")
                             if r and r.get("id")
                         }
+                        out_file.write("{ \"findings\": [")
                         for result in results:
                             rule = rules.get(result.get("ruleId"))
                             for location in result.get("locations"):
@@ -326,6 +327,8 @@ def convert_sarif(app_name, repo_context, sarif_files, findings_fname):
                                 lineno = location.get("physicalLocation", {})["region"][
                                     "startLine"
                                 ]
+                                if finding_id > 1:
+                                    out_file.write(",")
                                 finding = {
                                     "app": app_name,
                                     "type": "vuln",
@@ -359,5 +362,6 @@ def convert_sarif(app_name, repo_context, sarif_files, findings_fname):
                                 }
                                 out_file.write(json.dumps(finding))
                                 finding_id = finding_id + 1
+                        out_file.write("]}")
                     except Exception as e:
                         LOG.debug("Unable to convert the run to findings format")


### PR DESCRIPTION
Previously, we would just dump findings without any separation, making
the resulting file not a valid JSON file.

The correct format would be
```
{ "findings": [
 { "app": .... },
 { "app": .... },
]}
```