### PR TITLE
vuln -> extscan

### DIFF
--- a/lib/inspect.py
+++ b/lib/inspect.py
@@ -331,7 +331,7 @@ def convert_sarif(app_name, repo_context, sarif_files, findings_fname):
                                     out_file.write(",")
                                 finding = {
                                     "app": app_name,
-                                    "type": "vuln",
+                                    "type": "extscan",
                                     "title": result.get("message", {}).get("text"),
                                     "description": rule.get("fullDescription", {}).get(
                                         "text"


### PR DESCRIPTION
Classify findings coming from Scan as `extscan`. `vuln` expects
dataflow info as well, which is missing for results coming from Scan.