### PR TITLE
Build the AppImage via a Docker container.

### DIFF
--- a/appimage-builder.yml
+++ b/appimage-builder.yml
@@ -1,17 +1,17 @@
 version: 1
 script:
   # Remove any previous build
-  - rm -rf AppDir  | true
+  - rm -rf AppDir
   # Make usr and icons dirs
   - mkdir -p AppDir/usr/src
-  - mkdir -p AppDir/usr/local/lib
+  - mkdir -p AppDir/usr/local/lib/x86_64-linux-gnu
   - mkdir -p AppDir/usr/share/{metainfo,icons}
   # Copy the python application code into the AppDir
   - cp appimage-reqs.sh scan lib tools_config AppDir/usr/src -r
   - cp tools_config/scan.png AppDir/usr/share/icons/
   - cp tools_config/io.shiftleft.scan.appdata.xml AppDir/usr/share/metainfo/
   # Install application dependencies
-  - python3 -m pip install --no-cache-dir --ignore-installed --prefix=/usr --root=AppDir -r ./requirements.txt
+  - python3 -m pip install --no-cache-dir --ignore-installed --prefix=/usr --root=AppDir -r ./requirements.txt --no-warn-script-location
   - mv AppDir/usr/bin/scan AppDir/usr/bin/depscan
   - chmod +x AppDir/usr/src/appimage-reqs.sh && AppDir/usr/src/appimage-reqs.sh AppDir
   - npm install --only=production --no-save --prefix AppDir/usr/local/lib yarn @appthreat/cdxgen @microsoft/rush

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && apt-get install -y python3.8 python3.8-dev \
+        python3-pip python3-setuptools patchelf desktop-file-utils \
+        libgdk-pixbuf2.0-dev php php-curl php-zip php-bcmath php-json \
+        php-pear php-mbstring php-dev wget curl git unzip \
+        adwaita-icon-theme libfuse2
+
+RUN wget https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage && chmod +x appimagetool-x86_64.AppImage && ./appimagetool-x86_64.AppImage --appimage-extract && ln -s /squashfs-root/AppRun /usr/local/bin/appimagetool
+RUN pip3 install git+https://github.com/AppImageCrafters/appimage-builder.git
+RUN wget https://github.com/AppImage/AppImageKit/releases/download/12/runtime-x86_64 -O /usr/local/bin/runtime-x86_64 && chmod +x /usr/local/bin/runtime-x86_64
+
+ENV UPDATE_INFO=gh-releases-zsync|ShiftLeftSecurity|sast-scan|latest|*x86_64.AppImage.zsync
+
+WORKDIR /build
+
+ENV PATH="/build/AppDir/usr/bin:/build/AppDir/usr/bin/nodejs/bin:${PATH}"
+
+CMD mkdir -p appimage-builder-cache && ln -fs /usr/local/bin/runtime-x86_64 appimage-builder-cache && appimage-builder --recipe appimage-builder.yml --skip-test

--- a/builder.sh
+++ b/builder.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker run -v `pwd`:/build shiftleft/sast-scan-builder


### PR DESCRIPTION
This is in preparation of building the whole thing on Jenkins; the workaround for the AppImage tool itself running is due to the nesting of FUSE in Docker, which we're not gonna work around due to security. Fortunately simply extracting it works fine and doesn't require any other tooling. It also complains about `io.shiftleft.scan.desktop` being missing, but it *is* contained in the final output, so I think that's not a real warning after all.