### PR TITLE
Add separate script for Docker image building.

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker run -v `pwd`:/build shiftleft/sast-scan-builder

--- a/make-builder.sh
+++ b/make-builder.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+GIT_HASH=$(git rev-parse HEAD)
+GIT_TAG=$(git describe --tags)
+DOCKER_BASE_HASH=$(date -u +%F)
+
+docker build \
+       -t shiftleft/sast-scan-builder:latest \
+       -t shiftleft/sast-scan-builder:$GIT_TAG \
+       -t shiftleft/sast-scan-builder:$GIT_HASH \
+       -t shiftleft/sast-scan-builder:$DOCKER_BASE_HASH \
+       --label git.tag=$GIT_TAG \
+       --label git.hash=$GIT_HASH \
+       --label git.project=sast-scan \
+       --label git.clone-url=git@github.com:ShiftLeftSecurity/sast-scan.git \
+       --label git.github-url=https://github.com/ShiftLeftSecurity/sast-scan \
+       -f builder.Dockerfile .
+
+docker push shiftleft/sast-scan-builder:latest
+docker push shiftleft/sast-scan-builder:$GIT_TAG
+docker push shiftleft/sast-scan-builder:$GIT_HASH
+docker push shiftleft/sast-scan-builder:$DOCKER_BASE_HASH

--- a/run-builder.sh
+++ b/run-builder.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+GIT_HASH=$(git rev-parse HEAD)
+GIT_TAG=$(git describe --tags)
+DOCKER_BASE_HASH=$(date -u +%F)
+
+docker run -v `pwd`:/build shiftleft/sast-scan-builder
+
+mv scan-latest-x86_64.AppImage scan-$GIT_TAG-x86_64.AppImage


### PR DESCRIPTION
This is in preparation for having this automatically done in Jenkins.

One issue might be that the tagging isn't done on every commit on `master` as we have elsewhere.