### PR TITLE
Enable OSS Risk Audit

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -12,9 +12,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
+    - name: Cache multiple paths
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ github.workspace }}/db
+        key: ${{ runner.os }}-${{ hashFiles('requirements*.txt') }}
     - name: Perform Scan
       uses: ShiftLeftSecurity/scan-action@master
       env:
+        VDB_HOME: ${{ github.workspace }}/db
         WORKSPACE: ""
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/lib/analysis.py
+++ b/lib/analysis.py
@@ -75,8 +75,12 @@ def calculate_depscan_metrics(dep_data):
                 metrics[f"{usage}_{severity}"] += 1
                 if usage == "required":
                     required_pkgs_found = True
-        metrics[severity] += 1
-        metrics["total"] += 1
+        # Ignore unknown severity for now
+        if severity == "unknown":
+            continue
+        else:
+            metrics[severity] += 1
+            metrics["total"] += 1
     return metrics, required_pkgs_found
 
 
@@ -110,6 +114,9 @@ def summary(
     # Collect stats from depscan files if available
     if depscan_files:
         for df in depscan_files:
+            # Skip analyzing risk audit files
+            if "risk" in df:
+                continue
             with open(df, mode="r") as drep_file:
                 dep_data = get_depscan_data(drep_file)
                 if not dep_data:

--- a/lib/executor.py
+++ b/lib/executor.py
@@ -218,6 +218,11 @@ def execute_default_cmd(  # scan:ignore
         ei = default_cmd.find(")", si + 10)
         ext = default_cmd[si + 10 : ei]
         filelist = utils.find_files(src, ext)
+        # Temporary fix for the yaml issue
+        if ext == "yaml":
+            yml_list = utils.find_files(src, "yml")
+            if yml_list:
+                filelist.extend(yml_list)
         delim = " "
         default_cmd = default_cmd.replace(
             filelist_prefix + ext + ")", delim.join(filelist)

--- a/scan
+++ b/scan
@@ -578,15 +578,6 @@ def sec_scan(src, reports_dir, convert, repo_context):
       repo_context Repo context
     """
     if not utils.check_command("njsscan"):
-        LOG.debug(
-            "njsscan is no longer bundled with scan. Please use shiftleft/scan-oss container image if this tool is required."
-        )
-        LOG.debug(
-            "Know any decent open-source SAST tool for JavaScript? It should use AST and CFG and not just regex or grep. Please let us know :thumbsup:"
-        )
-        LOG.debug(
-            "Please feel free to try ShiftLeft NG SAST. To enable visit https://www.shiftleft.io/register to signup and pass the tokens as environment variables!"
-        )
         return
     convert_args = []
     report_fname = utils.get_report_file("source-js", reports_dir, convert)


### PR DESCRIPTION
Set the environment variable ENABLE_OSS_RISK=true to enable this feature for node.js/npm projects.