### PR TITLE
Add .vdb to ignore_files list

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -188,6 +188,7 @@ ignore_files = [
     ".snap",
     ".pb.go",
     ".tests.py",
+    ".vdb",
 ]
 
 # Tool specific ignored rules


### PR DESCRIPTION
This is the simple commit just to count on the .vdb files.
Still haven't ensure the vulnerability cache db is present in a different directory instead of the workspace