### PR TITLE
Use correct gitleaks args in tricks documentation

### DIFF
--- a/docs/TRICKS.md
+++ b/docs/TRICKS.md
@@ -45,7 +45,7 @@ Below is an example.
       "--repo-path=%(src)s",
       "--redact",
       "--report=%(report_fname_prefix)s.json",
-      "--report-format=json"
+      "--format=json"
     ]
   }
 }


### PR DESCRIPTION
I'm not sure if gitleaks ever had a `report-format` option, but it definitely doesn't any more. I ran into this because I needed to use a custom configuration with gitleaks to incorporate some additional regexes, and as I understand it, the only way to do that is with a .sastscanrc file. I started by just copying and extending the snippet from this TRICKS page and didn't realize the bad arg to gitleaks was the root cause of the issue I was seeing.

The bad arg causes gitleaks to error but the behavior I saw with scan was a false pass that seemed to succeed but without finding secrets that I knew gitleaks should have been finding.

Ultimately a pebkac issue :smile: but I think it'd be helpful to remove the invalid opt from the documentation to hopefully prevent the same from happening to anyone else.

Finally, thanks for a wonderful tool! Took some time to figure out this issue but I've really been enjoying things now that I've got it working.