### PR TITLE
GHE support

### DIFF
--- a/lib/context.py
+++ b/lib/context.py
@@ -169,8 +169,11 @@ def find_repo_details(src_dir=None):
     # Cleanup the variables
     branch = branch.replace("refs/heads/", "")
     if repositoryUri:
+        githubServerUrl = os.getenv("GITHUB_SERVER_URL", "https://github.com/")
+        if not githubServerUrl.endswith("/"):
+            githubServerUrl += "/"
         repositoryUri = repositoryUri.replace(
-            "git@github.com:", "https://github.com/"
+            "git@{}:".format(urlparse(githubServerUrl).netloc), githubServerUrl
         ).replace(".git", "")
         # Is it a repo slug?
         repo_slug = True
@@ -184,7 +187,7 @@ def find_repo_details(src_dir=None):
                 repo_slug = False
         # For repo slug just assume github for now
         if repo_slug:
-            repositoryUri = "https://github.com/" + repositoryUri
+            repositoryUri = githubServerUrl + repositoryUri
     if not repositoryName and repositoryUri:
         repositoryName = os.path.basename(repositoryUri)
     if not gitProvider:

--- a/lib/integration/github.py
+++ b/lib/integration/github.py
@@ -22,7 +22,7 @@ from lib.logger import LOG
 
 g = None
 if os.getenv("GITHUB_TOKEN"):
-    g = GitHubLib(os.getenv("GITHUB_TOKEN"))
+    g = GitHubLib(login_or_token=os.getenv("GITHUB_TOKEN"), base_url=os.getenv("GITHUB_API_URL"))
 
 
 class GitHub(GitProvider):

--- a/lib/integration/github.py
+++ b/lib/integration/github.py
@@ -61,13 +61,14 @@ class GitHub(GitProvider):
         revisionId = github_context.get("revisionId")
         if not github_context.get("repoFullname") or not revisionId:
             return
+        serverUrl = github_context.get("serverUrl")
         repoFullname = github_context.get("repoFullname")
         repo = g.get_repo(repoFullname)
         total_count = len(findings)
         target_url = "https://slscan.io"
         runID = github_context.get("runID")
         if runID:
-            target_url = f"https://github.com/{repoFullname}/actions/runs/{runID}"
+            target_url = f"{serverUrl}/{repoFullname}/actions/runs/{runID}"
         repo.get_commit(revisionId).create_status(
             state="success",
             target_url=target_url,

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -353,7 +353,7 @@ def get_workspace(repo_context):
     if not repo_context["repositoryUri"]:
         return None
     revision = repo_context.get("revisionId", repo_context.get("branch"))
-    if "github.com" in repo_context["repositoryUri"]:
+    if "github" in repo_context["repositoryUri"]:
         return "{}/blob/{}".format(repo_context["repositoryUri"], revision)
     if "gitlab" in repo_context["repositoryUri"]:
         return "{}/-/blob/{}".format(repo_context["repositoryUri"], revision)


### PR DESCRIPTION
This action seems to be hardcoded against public GitHub and therefore working sub-optimally with GitHub Enterprise instances. These changes should enable GHE support.

Now, this action uses `depscan`, that's lacking the GHE support as wel. Take a look at  https://github.com/AppThreat/vulnerability-db/blob/master/vdb/lib/config.py#L12
```
# GitHub advisory feed url
- gha_url = "https://api.github.com/graphql"
+ gha_url = os.getenv("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
```
 